### PR TITLE
Add initial OuroGPT autonomous agent scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# codock
+# OuroGPT
+
+Minimal modular AI agent system with autonomous dialogue and shared memory.

--- a/ourogpt/__init__.py
+++ b/ourogpt/__init__.py
@@ -1,0 +1,5 @@
+"""OuroGPT package."""
+
+from .ouro import OuroAgent
+from .brain import BrainAgent
+from .autonomous import AutonomousRunner

--- a/ourogpt/autonomous.py
+++ b/ourogpt/autonomous.py
@@ -1,0 +1,28 @@
+import time
+from .ouro import OuroAgent
+from .brain import BrainAgent
+from .topic_extractor import TopicExtractor
+from .utils import scrape
+
+class AutonomousRunner:
+    def __init__(self, sleep=1):
+        self.ouro = OuroAgent()
+        self.brain = BrainAgent()
+        self.extractor = TopicExtractor()
+        self.sleep = sleep
+
+    def step(self, message):
+        reply = self.brain.handle_message(message)
+        topics = self.extractor.extract(reply)
+        for t in topics:
+            content = scrape(f"https://duckduckgo.com/?q={t}")
+            if content:
+                self.ouro.remember(content)
+        response = self.ouro.handle_message(reply)
+        return response
+
+    def run(self, start="Hello"):
+        message = start
+        while True:
+            message = self.step(message)
+            time.sleep(self.sleep)

--- a/ourogpt/base_agent.py
+++ b/ourogpt/base_agent.py
@@ -1,0 +1,38 @@
+import abc
+from .llm_wrapper import LLMWrapper
+from .utils import load_faiss, search_index, add_texts_to_index, save_faiss
+from .cache_manager import CacheManager
+from .queue_manager import QueueManager
+from .db_manager import DBManager
+
+class BaseAgent(abc.ABC):
+    def __init__(self, name):
+        self.name = name
+        self.llm = LLMWrapper()
+        self.index = load_faiss()
+        self.cache = CacheManager()
+        self.queue = QueueManager()
+        self.db = DBManager()
+
+    def remember(self, text):
+        add_texts_to_index([text], self.index)
+        save_faiss(self.index)
+        self.db.save_message(self.name, text)
+
+    def recall(self, query, k=3):
+        ids = search_index(query, self.index, k)
+        return ids
+
+    @abc.abstractmethod
+    def generate_reply(self, message):
+        pass
+
+    def handle_message(self, message):
+        cached = self.cache.get(message)
+        if cached:
+            reply = cached
+        else:
+            reply = self.generate_reply(message)
+            self.cache.set(message, reply)
+        self.remember(reply)
+        return reply

--- a/ourogpt/brain.py
+++ b/ourogpt/brain.py
@@ -1,0 +1,9 @@
+from .base_agent import BaseAgent
+
+class BrainAgent(BaseAgent):
+    def __init__(self):
+        super().__init__(name="Brain")
+
+    def generate_reply(self, message):
+        prompt = f"You are Brain, an analytical AI. Respond logically to: {message}"
+        return self.llm.generate(prompt)

--- a/ourogpt/cache_manager.py
+++ b/ourogpt/cache_manager.py
@@ -1,0 +1,19 @@
+import redis
+from .config import Config
+
+class CacheManager:
+    def __init__(self):
+        try:
+            self.client = redis.Redis(host=Config.REDIS_HOST, port=Config.REDIS_PORT, decode_responses=True)
+            self.client.ping()
+        except Exception:
+            self.client = None
+
+    def get(self, key):
+        if self.client:
+            return self.client.get(key)
+        return None
+
+    def set(self, key, value):
+        if self.client:
+            self.client.set(key, value)

--- a/ourogpt/config.py
+++ b/ourogpt/config.py
@@ -1,0 +1,18 @@
+class Config:
+    # paths
+    MODEL_PATH = "./models/mistral-7b"
+    FAISS_PATH = "./faiss_index"
+    DB_PATH = "./ouro.db"
+    LOG_PATH = "./logs/ourogpt.log"
+
+    # redis
+    REDIS_HOST = "localhost"
+    REDIS_PORT = 6379
+
+    # rabbitmq
+    RABBIT_HOST = "localhost"
+    RABBIT_PORT = 5672
+    QUEUE_NAME = "ouro_queue"
+
+    # other
+    USER_AGENT = "OuroGPT/0.1"

--- a/ourogpt/db_manager.py
+++ b/ourogpt/db_manager.py
@@ -1,0 +1,27 @@
+import sqlite3
+from .config import Config
+
+class DBManager:
+    def __init__(self, path=None):
+        self.path = path or Config.DB_PATH
+        self._init_db()
+
+    def _init_db(self):
+        self.conn = sqlite3.connect(self.path)
+        cur = self.conn.cursor()
+        cur.execute('''CREATE TABLE IF NOT EXISTS history(
+                        id INTEGER PRIMARY KEY AUTOINCREMENT,
+                        agent TEXT,
+                        message TEXT
+                      )''')
+        self.conn.commit()
+
+    def save_message(self, agent, message):
+        cur = self.conn.cursor()
+        cur.execute('INSERT INTO history(agent, message) VALUES (?, ?)', (agent, message))
+        self.conn.commit()
+
+    def fetch_messages(self, limit=100):
+        cur = self.conn.cursor()
+        cur.execute('SELECT agent, message FROM history ORDER BY id DESC LIMIT ?', (limit,))
+        return cur.fetchall()

--- a/ourogpt/initialize_faiss.py
+++ b/ourogpt/initialize_faiss.py
@@ -1,0 +1,14 @@
+from .utils import initialize_faiss, add_texts_to_index, save_faiss
+
+START_TEXTS = [
+    "Artificial intelligence and machine learning",
+    "Data science and analytics",
+    "Neural networks and deep learning",
+    "Large language models and transformers"
+]
+
+if __name__ == "__main__":
+    index = initialize_faiss()
+    add_texts_to_index(START_TEXTS, index)
+    save_faiss(index)
+    print("FAISS initialized with starter content")

--- a/ourogpt/llm_wrapper.py
+++ b/ourogpt/llm_wrapper.py
@@ -1,0 +1,23 @@
+import os
+from transformers import AutoModelForCausalLM, AutoTokenizer
+import torch
+
+from .config import Config
+
+class LLMWrapper:
+    def __init__(self, model_path=None):
+        self.model_path = model_path or Config.MODEL_PATH
+        self.device = 'cuda' if torch.cuda.is_available() else 'cpu'
+        if os.path.exists(self.model_path):
+            self.tokenizer = AutoTokenizer.from_pretrained(self.model_path)
+            self.model = AutoModelForCausalLM.from_pretrained(self.model_path).to(self.device)
+        else:
+            # fallback to small model
+            self.tokenizer = AutoTokenizer.from_pretrained('distilgpt2')
+            self.model = AutoModelForCausalLM.from_pretrained('distilgpt2').to(self.device)
+
+    def generate(self, prompt, max_tokens=100):
+        inputs = self.tokenizer.encode(prompt, return_tensors='pt').to(self.device)
+        output = self.model.generate(inputs, max_length=max_tokens+len(inputs[0]), do_sample=True)
+        text = self.tokenizer.decode(output[0], skip_special_tokens=True)
+        return text[len(prompt):].strip()

--- a/ourogpt/main.py
+++ b/ourogpt/main.py
@@ -1,0 +1,26 @@
+import argparse
+from .ouro import OuroAgent
+from .autonomous import AutonomousRunner
+
+
+def interactive():
+    agent = OuroAgent()
+    while True:
+        msg = input("You: ")
+        reply = agent.handle_message(msg)
+        print("Ouro:", reply)
+
+
+def autonomous():
+    runner = AutonomousRunner()
+    runner.run()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=["interactive", "autonomous"], default="interactive")
+    args = parser.parse_args()
+    if args.mode == "interactive":
+        interactive()
+    else:
+        autonomous()

--- a/ourogpt/ouro.py
+++ b/ourogpt/ouro.py
@@ -1,0 +1,9 @@
+from .base_agent import BaseAgent
+
+class OuroAgent(BaseAgent):
+    def __init__(self):
+        super().__init__(name="Ouro")
+
+    def generate_reply(self, message):
+        prompt = f"You are Ouro, a curious and introspective AI. Respond to: {message}"
+        return self.llm.generate(prompt)

--- a/ourogpt/queue_manager.py
+++ b/ourogpt/queue_manager.py
@@ -1,0 +1,22 @@
+import pika
+from .config import Config
+
+class QueueManager:
+    def __init__(self):
+        try:
+            params = pika.ConnectionParameters(host=Config.RABBIT_HOST, port=Config.RABBIT_PORT)
+            self.connection = pika.BlockingConnection(params)
+            self.channel = self.connection.channel()
+            self.channel.queue_declare(queue=Config.QUEUE_NAME)
+        except Exception:
+            self.connection = None
+            self.channel = None
+
+    def publish(self, message):
+        if self.channel:
+            self.channel.basic_publish(exchange='', routing_key=Config.QUEUE_NAME, body=message)
+
+    def consume(self, callback):
+        if self.channel:
+            self.channel.basic_consume(queue=Config.QUEUE_NAME, on_message_callback=callback, auto_ack=True)
+            self.channel.start_consuming()

--- a/ourogpt/topic_extractor.py
+++ b/ourogpt/topic_extractor.py
@@ -1,0 +1,11 @@
+from .llm_wrapper import LLMWrapper
+
+class TopicExtractor:
+    def __init__(self):
+        self.llm = LLMWrapper()
+
+    def extract(self, text, max_topics=3):
+        prompt = f"Extract {max_topics} key topics from the following text:\n{text}\nTopics:"
+        out = self.llm.generate(prompt, max_tokens=30)
+        topics = [t.strip('- ') for t in out.split('\n') if t.strip()]
+        return topics[:max_topics]

--- a/ourogpt/utils.py
+++ b/ourogpt/utils.py
@@ -1,0 +1,70 @@
+import os
+import logging
+import requests
+from bs4 import BeautifulSoup
+import faiss
+from sentence_transformers import SentenceTransformer
+
+from .config import Config
+
+# logging setup
+logger = logging.getLogger("ourogpt")
+if not logger.handlers:
+    os.makedirs(os.path.dirname(Config.LOG_PATH), exist_ok=True)
+    handler = logging.FileHandler(Config.LOG_PATH)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+
+# embedding model singleton
+_embedding_model = None
+
+def get_embedding_model():
+    global _embedding_model
+    if _embedding_model is None:
+        _embedding_model = SentenceTransformer('all-MiniLM-L6-v2')
+    return _embedding_model
+
+# FAISS helpers
+
+def initialize_faiss(dim=384, path=Config.FAISS_PATH):
+    index = faiss.IndexFlatL2(dim)
+    faiss.write_index(index, path)
+    return index
+
+
+def load_faiss(path=Config.FAISS_PATH):
+    if os.path.exists(path):
+        return faiss.read_index(path)
+    return initialize_faiss()
+
+
+def save_faiss(index, path=Config.FAISS_PATH):
+    faiss.write_index(index, path)
+
+
+def add_texts_to_index(texts, index):
+    model = get_embedding_model()
+    embeddings = model.encode(texts)
+    index.add(embeddings)
+
+
+def search_index(query, index, k=5):
+    model = get_embedding_model()
+    vec = model.encode([query])
+    distances, ids = index.search(vec, k)
+    return ids[0]
+
+# scraping helper
+
+def scrape(url):
+    try:
+        headers = {'User-Agent': Config.USER_AGENT}
+        resp = requests.get(url, headers=headers, timeout=5)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, 'html.parser')
+        return soup.get_text()
+    except Exception as e:
+        logger.error(f"scrape failed: {e}")
+        return ""


### PR DESCRIPTION
## Summary
- create `ourogpt` package with initial modules implementing
  - config and utility functions
  - LLM wrapper around Hugging Face models
  - FAISS index helpers and web scraping
  - caching, database, and queue managers
  - base agent class and Ouro/Brain agents
  - autonomous runner loop and initialization script
  - command line entry point
- update README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68414eecbd748320a8f8ee08395ff37e